### PR TITLE
paul/jsx-token-fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,18 +42,20 @@ export default (template, tokenDict) => {
     //   so ['you have ', '50', ' friends in common with', <Link href="/joe">Joe</Link>]
     //   becomes ['you have 50 friends in common with', <Link href="/joe">Joe</Link>]
     let strAccum = ''
-    return renderedParts.reduce((arr, part) => {
-      if (typeof part !== 'string') {
-        if (!strAccum.length) {
-          return arr.concat(part)
+    return renderedParts
+      .reduce((arr, part) => {
+        if (typeof part !== 'string') {
+          if (!strAccum.length) {
+            return arr.concat(part)
+          }
+          const flushedStr = strAccum
+          strAccum = ''
+          return arr.concat([flushedStr, part])
         }
-        const flushedStr = strAccum
-        strAccum = ''
-        return arr.concat([flushedStr, part])
-      }
-      strAccum = strAccum.concat(part)
-      return arr
-    }, [])
+        strAccum = strAccum.concat(part)
+        return arr
+      }, [])
+      .concat(strAccum)
   }
   return renderedParts.join('')
 }

--- a/index.test.js
+++ b/index.test.js
@@ -21,7 +21,7 @@ test('quotes are html-ified', () => {
 })
 
 test('tokens are replaced, jsx value', () => {
-  const template = 'found {COUNT} instances of {TERM}'
+  const template = 'found {COUNT} instances of {TERM} in the document'
   const tokenDict = {
     COUNT: 42,
     TERM: <Link href="/presence">Presence</Link>,
@@ -31,6 +31,7 @@ test('tokens are replaced, jsx value', () => {
     <Link key={1} href="/presence">
       Presence
     </Link>,
+    ' in the document',
   ])
   const result = TestRenderer.create(renderTemplate(template, tokenDict))
   expect(result.toJSON()).toEqual(expected.toJSON())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-templates",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Simple library to render plaintext templates to React elements",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fixes an issue where the last plaintext (string) part of a template was not included in the output.