### PR TITLE
paul/no-replace-undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ export default (template, tokenDict) => {
     }
     const key = part.match(keyRegex)[1]
     const val = tokenDict[key]
+    // if key isn't in the dict, leave the string alone
+    if (!val) {
+      return arr.concat(part)
+    }
     // if the value is a react element, add a key and concat
     if (React.isValidElement(val)) {
       foundJsx = true

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import TestRenderer from 'react-test-renderer'
-import renderTemplate from './'
+import renderTemplate, { DOUBLE_CURLY } from './'
 
 // test component
 const Link = ({ href, children }) => <a href={href}>{children}</a>
@@ -50,10 +50,10 @@ test('keys are added to jsx elements', () => {
   expect(linkNodes[1]._fiber.key).toEqual('1')
 })
 
-test('handle undefined tokens', () => {
+test('do not replace tokens unless they are in the dict', () => {
   const template = 'found {COUNT} instances of {TERM}'
   const tokenDict = { COUNT: 42 }
   expect(renderTemplate(template, tokenDict)).toBe(
-    'found 42 instances of undefined'
+    'found 42 instances of {TERM}'
   )
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-text-templates",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Simple library to render plaintext templates to React elements",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Do not replace a token if the key isn't found in the dict